### PR TITLE
Require at least version 1.8 of the JDK

### DIFF
--- a/third_party/buildtools/java_rules.js
+++ b/third_party/buildtools/java_rules.js
@@ -15,7 +15,7 @@ try {
 function JavaTool(engine) {
   rule.Tool.call(this, engine, 'java',
                  '$javac', ['-version'],
-                 '(?<=javac )1\\.[7-9]', '1.7');
+                 '(?<=javac )1\\.[8-9]', '1.8');
 }
 JavaTool.prototype = Object.create(rule.Tool.prototype);
 


### PR DESCRIPTION
The Java code uses default interface methods, which do not exist in Java 7, so if someone only has Java 7 installed, then the current version check will pass, but the build will fail.