### PR TITLE
Semi long lived service

### DIFF
--- a/shipshape/cli/shipshape.go
+++ b/shipshape/cli/shipshape.go
@@ -259,11 +259,7 @@ func main() {
 func startShipshapeService(image, absRoot string, analyzers []string) (*client.Client, error) {
 	// If this doesn't match the image, stop and restart the service.
 	// Otherwise, use the existing one.
-	match, err := docker.ImageMatches(image, "shipping_container")
-	if err != nil {
-		return nil, err
-	}
-	if !match {
+	if !docker.ImageMatches(image, "shipping_container") {
 		glog.Infof("Restarting container with %s", image)
 		stop("shipping_container", 0)
 		result := docker.RunService(image, "shipping_container", absRoot, localLogs, analyzers)

--- a/shipshape/test/end_to_end_test.sh
+++ b/shipshape/test/end_to_end_test.sh
@@ -113,12 +113,14 @@ POSTMESSAGE_COUNT=$(grep PostMessage $LOG_FILE | wc -l)
 ERRORPRONE_COUNT=$(grep ErrorProne $LOG_FILE | wc -l)
 ANDROIDLINT_COUNT=$(grep AndroidLint $LOG_FILE | wc -l)
 FAILURE_COUNT=$(grep Failure $LOG_FILE | wc -l)
-[[ $JSHINT_COUNT == 8 ]] || { echo "Wrong number of JSHint results, expected 8, found $JSHINT_COUNT" 1>&2 ; exit 1; }
-[[ $POSTMESSAGE_COUNT == 1 ]] || { echo "Wrong number of PostMessage results, expected 1, found $POSTMESSAGE_COUNT" 1>&2 ; exit 1; }
-[[ $ERRORPRONE_COUNT == 2 ]] || { echo "Wrong number of ErrorProne results, expected 2, found $ERRORPRONE_COUNT" 1>&2 ; exit 1; }
-[[ $ANDROIDLINT_COUNT == 8 ]] || { echo "Wrong number of AndroidLint results, expected 9, found $ANDROIDLINT_COUNT" 1>&2 ; exit 1; }
-[[ $FAILURE_COUNT == 0 ]] || { echo "Some analyses failed; please check $LOG_FILE" 1>&2 ; exit 1; }
+TEST_STATUS=0
+[[ $JSHINT_COUNT == 8 ]] || { echo "Wrong number of JSHint results, expected 8, found $JSHINT_COUNT" 1>&2 ; TEST_STATUS=1; }
+[[ $POSTMESSAGE_COUNT == 1 ]] || { echo "Wrong number of PostMessage results, expected 1, found $POSTMESSAGE_COUNT" 1>&2 ; TEST_STATUS=1; }
+[[ $ERRORPRONE_COUNT == 2 ]] || { echo "Wrong number of ErrorProne results, expected 2, found $ERRORPRONE_COUNT" 1>&2 ; TEST_STATUS=1; }
+[[ $ANDROIDLINT_COUNT == 8 ]] || { echo "Wrong number of AndroidLint results, expected 9, found $ANDROIDLINT_COUNT" 1>&2 ; TEST_STATUS=1; }
+[[ $FAILURE_COUNT == 0 ]] || { echo "Some analyses failed; please check $LOG_FILE" 1>&2 ; TEST_STATUS=1; }
 
-echo "Success! Analyzer produced expected number of results. Full output in $LOG_FILE"
-
-exit 0
+if [[ $TEST_STATUS -eq 0 ]]; then
+  echo "Success! Analyzer produced expected number of results. Full output in $LOG_FILE"
+fi
+exit $(($TEST_STATUS))

--- a/shipshape/test/end_to_end_test.sh
+++ b/shipshape/test/end_to_end_test.sh
@@ -51,7 +51,7 @@ if [[ "$IS_LOCAL_RUN" == true ]]; then
     IFS=':' # Set global string separator so we can split the image name
     names=(${container[@]})
     name=${names[1]}
-    docker tag $name:$TAG $REPO/$name:$TAG
+    docker tag -f $name:$TAG $REPO/$name:$TAG
     IFS=' ' # reset it back to a space
   done
 fi

--- a/shipshape/util/docker/docker.go
+++ b/shipshape/util/docker/docker.go
@@ -248,3 +248,28 @@ func Stop(container string, waitTime time.Duration, remove bool) CommandResult {
 
 	return CommandResult{stdout.String(), stderr.String(), err}
 }
+
+func OutOfDate(image string) bool {
+	return true
+}
+
+func ImageMatches(image, container string) (bool, error) {
+	imageHash, err := inspect(image, "{{.Id}}")
+	if err != nil {
+		return false, err
+	}
+	containerHash, err := inspect(container, "{{.Id}}")
+	if err != nil {
+		return false, err
+	}
+	return bytes.Equal(imageHash, containerHash), nil
+}
+
+func inspect(name, format string) ([]byte, error) {
+	var formatter string
+	if len(format) != 0 {
+		formatter = fmt.Sprintf("--format='%s'", format)
+	}
+	cmd := exec.Command("docker", "inspect", formatter, name)
+	return cmd.CombinedOutput()
+}

--- a/shipshape/util/docker/docker.go
+++ b/shipshape/util/docker/docker.go
@@ -249,20 +249,28 @@ func Stop(container string, waitTime time.Duration, remove bool) CommandResult {
 	return CommandResult{stdout.String(), stderr.String(), err}
 }
 
+// OutOfDate returns true if the image specified
+// has not been pulled recently.
 func OutOfDate(image string) bool {
+	// TODO(ciera): Rather than always return true,
+	// check a file that contains the last time this
+	// image was updated, and only return true if it
+	// is at least N days old.
 	return true
 }
 
-func ImageMatches(image, container string) (bool, error) {
+// ImageMatches returns whether the container is running
+// the current version of image.
+func ImageMatches(image, container string) bool {
 	imageHash, err := inspect(image, "{{.Id}}")
 	if err != nil {
-		return false, err
+		return false
 	}
-	containerHash, err := inspect(container, "{{.Id}}")
+	containerHash, err := inspect(container, "{{.Image}}")
 	if err != nil {
-		return false, err
+		return false
 	}
-	return bytes.Equal(imageHash, containerHash), nil
+	return bytes.Equal(imageHash, containerHash)
 }
 
 func inspect(name, format string) ([]byte, error) {


### PR DESCRIPTION
Turns shipshape into a semi-long-lived service. It will only tear down the container and restart it when the image it has pulled does not match the image running. Still to do is to only pull images when they are N days out of date.