### PR TITLE
Modify scripts for updating kythe

### DIFF
--- a/third_party/kythe/README.google
+++ b/third_party/kythe/README.google
@@ -1,5 +1,5 @@
-URL: https://github.com/google/kythe/tree/250bb910b0edb5ccf99971692f8068a66ba87eac
-Version: 250bb910b0edb5ccf99971692f8068a66ba87eac
+URL: https://github.com/google/kythe/tree/c9f42bfb7e5b8d33834232e181fcf6a4e8105629
+Version: c9f42bfb7e5b8d33834232e181fcf6a4e8105629
 License: Apache 2.0 http://www.apache.org/licenses/LICENSE-2.0
 License File: LICENSE
 


### PR DESCRIPTION
Modifies the scripts to allow us to push out our own versions of kythe.

Unfortunately, this does not seem to fix the problem where ErrorProne is not producing results. It does fix the problem with the kythe image no longer existing. I tested the new image locally (ErrorProne fails, but kythe made compilation units) and am currently pushing the image.