### PR TITLE
Fixes Docker and Travis build failures related to Android lint.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,12 @@ jdk:
   - oraclejdk8
 go:
   - 1.4
+before_install:
+  - wget http://dl.google.com/android/android-sdk_r23-linux.tgz
+  - tar xvf android-sdk_r23-linux.tgz
+  - export PATH=${PATH}:${PWD}/android-sdk-linux/tools:${PWD}/android-sdk-linux/platform-tools
+  - echo "sdk.dir=${PWD}/android-sdk-linux" > local.properties
+  - echo "y" | android update sdk --no-ui --filter platform-tools,tools
 script:
   - jdk_switcher use oraclejdk8
   - ./campfire test shipshape/...

--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ To install all of them:
 
 Update `.campfire_settings` in the root directory to point to the correct tools paths, if necessary.
 
+To run the unit tests, you'll need Android `lint` (part of the
+[Android SDK](https://developer.android.com/sdk/index.html)) installed in your
+system `PATH`.
+
 # Building/running CLI entirely locally #
 
 `$ ./test/end_to_end_test.sh local`

--- a/shipshape/androidlint_analyzer/androidlint/analyzer.go
+++ b/shipshape/androidlint_analyzer/androidlint/analyzer.go
@@ -65,6 +65,8 @@ func (ala Analyzer) Analyze(ctx *ctxpb.ShipshapeContext) ([]*notepb.Note, error)
 		defer os.Remove(tempReport.Name())
 
 		// TODO(ciera): Add project options (--classpath) when we have build information.
+		// TODO(clconway): The path to the binary should be configurable, especially since
+		// the "lint" command name is overloaded.
 		cmd := exec.Command("lint",
 			"--showall",
 			"--quiet",

--- a/shipshape/androidlint_analyzer/docker/Dockerfile
+++ b/shipshape/androidlint_analyzer/docker/Dockerfile
@@ -15,9 +15,10 @@
 FROM debian:wheezy
 
 # Make sure all package lists are up-to-date
-RUN apt-get update && apt-get upgrade -y &&  apt-get install -y \
-   -q  --no-install-recommends sudo openjdk-6-jre \
-   openjdk-6-jdk wget && apt-get clean
+RUN apt-get update && apt-get upgrade -y && \
+    apt-get install -y -q  --no-install-recommends \
+        sudo openjdk-6-jre openjdk-6-jdk unzip wget && \
+    apt-get clean
 
 # Set up AndroidLint
 # Get the jdk, then android.
@@ -27,6 +28,12 @@ RUN tar xvf android-sdk_r23-linux.tgz
 ENV PATH /android-sdk-linux/tools:$PATH
 RUN echo "y" | android update sdk --no-ui --filter platform-tools
 RUN echo "y" | android update sdk --no-ui --filter tools
+# This is a workaround for a failure in the "android update" command:
+# https://github.com/google/shipshape/issues/27
+# The update fails to clobber the /tools directory for some reason, so
+# we have to do the clobbering for it.
+RUN rm -rf /android-sdk-linux/tools
+RUN unzip /android-sdk-linux/temp/tools_*-linux.zip -d /android-sdk-linux/tools
 ENV PATH /android-sdk-linux/platform-tools:$PATH
 
 # Set up AndroidLintAnalzer


### PR DESCRIPTION
For some reason "android update" is failing to unpack the new tools and
obliterating the /tools dir in the process. But we can do by hand what
"android update" is failing to do: unpack the downloaded zip into /tools.

The end-to-end tests still fail with this change, but with a "executable not 
found" error.

Issue: https://github.com/google/shipshape/issues/27