### PR TITLE
Use "include" instead of "subninja" for rules.ninja

### DIFF
--- a/third_party/buildtools/engine.js
+++ b/third_party/buildtools/engine.js
@@ -562,7 +562,7 @@ function ninjaBuildHeader(engine) {
   for (var k in vars) {
     lines.push(k + ' = ' + vars[k]);
   }
-  lines.push('subninja ' +
+  lines.push('include ' +
       path.join(engine.settings.properties['buildtools_root'], 'rules.ninja'));
   return lines;
 }


### PR DESCRIPTION
rules.ninja only defines rules.  Up to ninja 1.5.x, include
and subninja do the same thing for ninja files that only define
rules.

In ninja 1.6, we hope to change rules to be scoped to the current
subninja ( https://github.com/martine/ninja/pull/921 ). With that
change, `subninja rules.ninja` would define the rules in a new scope
that closes at the end of the line and all the rules in rules.ninja
would be ignores.  `include` won't introduce a new scope and instead
add the rules in the context of the parent build.ninja file.

This change should have no effect on ninja up to 1.5.x, and it should
keep the build working as previously with newer ninja versions.